### PR TITLE
fix(orientation) : do not throw if "executionContext" is not inited yet

### DIFF
--- a/lib/command-helpers/test-context.js
+++ b/lib/command-helpers/test-context.js
@@ -1,13 +1,17 @@
 'use strict';
 
 const getTestContext = (context) => {
-    return context.type === 'hook' && /^"before each"/.test(context.title)
+    return context && context.type === 'hook' && /^"before each"/.test(context.title)
         ? context.ctx.currentTest
         : context;
 };
 
 const resetTestContextValues = (context, keys = []) => {
     const testCtx = getTestContext(context);
+
+    if (!testCtx) {
+        return;
+    }
 
     [].concat(keys).forEach((key) => {
         delete testCtx[key];

--- a/lib/commands/orientation.js
+++ b/lib/commands/orientation.js
@@ -6,7 +6,7 @@ module.exports = (browser) => {
     const baseOrientationFn = browser.orientation;
 
     browser.addCommand('orientation', async (orientation) => {
-        if (orientation) {
+        if (orientation && browser.executionContext) {
             resetTestContextValues(browser.executionContext, [TOP_TOOLBAR_SIZE, BOTTOM_TOOLBAR_LOCATION, WEB_VIEW_SIZE]);
         }
 

--- a/test/lib/command-helpers/test-context.js
+++ b/test/lib/command-helpers/test-context.js
@@ -27,16 +27,33 @@ describe('"test-context" helper', () => {
             assert.equal(ctx, browser.executionContext.ctx.currentTest);
         });
 
-        it('should return test context for not hook', () => {
-            browser.executionContext = {some: 'test'};
+        [
+            {
+                name: 'not hook',
+                executionContext: {some: 'test'}
+            },
+            {
+                name: 'falsy value',
+                executionContext: undefined
+            }
+        ].forEach(({name, executionContext}) => {
+            it(`shoult return passed context for ${name}`, () => {
+                browser.executionContext = executionContext;
 
-            const ctx = testCtx.getTestContext(browser.executionContext);
+                const ctx = testCtx.getTestContext(browser.executionContext);
 
-            assert.equal(ctx, browser.executionContext);
+                assert.equal(ctx, browser.executionContext);
+            });
         });
     });
 
     describe('"resetTestContextValues" method', () => {
+        it('should not throw if test context is falsy', () => {
+            browser.executionContext = undefined;
+
+            assert.doesNotThrow(() => testCtx.resetTestContextValues(browser.executionContext, ['foo', 'bar']));
+        });
+
         it('should reset value in test context for one passed key', () => {
             browser.executionContext = {foo: 'value'};
 

--- a/test/lib/commands/orientation.js
+++ b/test/lib/commands/orientation.js
@@ -46,11 +46,22 @@ describe('"orientation" command', () => {
         );
     });
 
-    it('should not reset toolbar and web view values in test context if "orientation" is not passed', async () => {
-        addOrientationCommand(browser);
+    describe('should not reset toolbar and web view values in test context if', () => {
+        it('"orientation" is not passed', async () => {
+            addOrientationCommand(browser);
 
-        await browser.orientation();
+            await browser.orientation();
 
-        assert.notCalled(resetTestContextValues);
+            assert.notCalled(resetTestContextValues);
+        });
+
+        it('"browser.executionContext" is not inited yet', async () => {
+            browser.executionContext = undefined;
+            addOrientationCommand(browser);
+
+            await browser.orientation('landscape');
+
+            assert.notCalled(resetTestContextValues);
+        });
     });
 });


### PR DESCRIPTION
### what is done:
- when hermione option "orientation" is set then first orientation change is complete before "executionContext" is specified. In this PR I fixed this problem.