### PR TITLE
fix(screenshot): set "left" and "top" crop coords to zero when they are negative

### DIFF
--- a/lib/command-helpers/element-utils/index.js
+++ b/lib/command-helpers/element-utils/index.js
@@ -64,7 +64,7 @@ exports.calcWebViewCoords = async (browser, {bodyWidth, pixelRatio = 1} = {}) =>
     return {
         width: Math.ceil(bodyWidth * pixelRatio),
         height: Math.ceil((webViewSize.height - topToolbarHeight - bottomToolbarHeight) * pixelRatio),
-        left: Math.floor((webViewSize.width - bodyWidth) / 2 * pixelRatio),
-        top: Math.floor(topToolbarHeight * pixelRatio)
+        left: Math.max(Math.floor((webViewSize.width - bodyWidth) / 2 * pixelRatio), 0),
+        top: Math.max(Math.floor(topToolbarHeight * pixelRatio), 0)
     };
 };

--- a/test/lib/command-helpers/element-utils/index.js
+++ b/test/lib/command-helpers/element-utils/index.js
@@ -228,31 +228,49 @@ describe('"element-utils" helper', () => {
             });
         });
 
-        describe('should correctly calc web view "left" coord', () => {
-            it('with substract passed body width from web view width and take half of it', async () => {
-                utils.getWebViewSize.withArgs(browser).returns({width: 20});
+        describe('web view "left" coord', () => {
+            describe('should correctly calc', () => {
+                it('with substract passed body width from web view width and take half of it', async () => {
+                    utils.getWebViewSize.withArgs(browser).returns({width: 20});
 
-                const {left} = await utils.calcWebViewCoords(browser, {bodyWidth: 10});
+                    const {left} = await utils.calcWebViewCoords(browser, {bodyWidth: 10});
 
-                assert.equal(left, 5);
+                    assert.equal(left, 5);
+                });
+
+                it('with multiply real web view width by passed pixel ratio', async () => {
+                    utils.getWebViewSize.withArgs(browser).returns({width: 20});
+
+                    const {left} = await utils.calcWebViewCoords(browser, {bodyWidth: 10, pixelRatio: 2});
+
+                    assert.equal(left, 10);
+                });
             });
 
-            it('with multiply real web view width by passed pixel ratio', async () => {
-                utils.getWebViewSize.withArgs(browser).returns({width: 20});
+            it('should set to zero if calculated coord is negative', async () => {
+                utils.getWebViewSize.withArgs(browser).returns({width: 10});
 
-                const {left} = await utils.calcWebViewCoords(browser, {bodyWidth: 10, pixelRatio: 2});
+                const {left} = await utils.calcWebViewCoords(browser, {bodyWidth: 20});
 
-                assert.equal(left, 10);
+                assert.equal(left, 0);
             });
         });
 
-        describe('should correctly calc web view "top" coord', () => {
-            it('with multiply top toolbar height by passed pixel ratio', async () => {
+        describe('web view "top" coord', () => {
+            it('should correctly calc with multiply top toolbar height by passed pixel ratio', async () => {
                 utils.getTopToolbarHeight.withArgs(browser).returns(2);
 
                 const {top} = await utils.calcWebViewCoords(browser, {pixelRatio: 2});
 
                 assert.equal(top, 4);
+            });
+
+            it('should set to zero if calculated coord is negative', async () => {
+                utils.getTopToolbarHeight.withArgs(browser).returns(-10);
+
+                const {top} = await utils.calcWebViewCoords(browser, {pixelRatio: 1});
+
+                assert.equal(top, 0);
             });
         });
 


### PR DESCRIPTION
### Description

In some strange cases width of body element can be more then web view width and in that case "left" crop coordinate calculated as negative value and everything freezes (looks like a bug inside pngjs).

In that PR that problem is fixed and uses zero if "left" or "top" crop coordinate calc as negative value.