### PR TITLE
feat: ability to work correctly with wdio@7 inside hermione

### DIFF
--- a/lib/command-helpers/context-switcher.js
+++ b/lib/command-helpers/context-switcher.js
@@ -2,6 +2,7 @@
 
 const {getTestContext, IS_NATIVE_CTX, WEB_VIEW_CTX} = require('./test-context');
 const {NATIVE_CONTEXT} = require('../constants');
+const {isWdioLatest} = require('../utils');
 
 exports.runInNativeContext = async function(browser, action, testCtx) {
     if (!testCtx) {
@@ -13,7 +14,9 @@ exports.runInNativeContext = async function(browser, action, testCtx) {
     }
 
     if (!testCtx[WEB_VIEW_CTX]) {
-        const {value: contexts} = await browser.contexts();
+        const result = await browser.contexts();
+        const contexts = isWdioLatest(browser) ? result : result.value;
+
         testCtx[WEB_VIEW_CTX] = contexts[1];
     }
 

--- a/lib/command-helpers/element-utils/index.js
+++ b/lib/command-helpers/element-utils/index.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const {withExisting, withNativeCtx, withTestCtxMemo} = require('./decorators');
 const {TOP_TOOLBAR_SIZE, BOTTOM_TOOLBAR_LOCATION, WEB_VIEW_SIZE, PIXEL_RATIO} = require('../test-context');
 const {TOP_TOOLBAR, BOTTOM_TOOLBAR, WEB_VIEW} = require('../../native-locators');
+const {isWdioLatest} = require('../../utils');
 
 exports.getTopToolbarHeight = async (browser) => {
     const action = {fn: browser.getElementSize, args: TOP_TOOLBAR, default: {width: 0, height: 0}};
@@ -48,7 +49,11 @@ exports.getElemCenterLocation = async (browser, selector) => {
 };
 
 exports.getPixelRatio = async (browser) => {
-    const action = {fn: async () => (await browser.execute(() => window.devicePixelRatio)).value};
+    const action = {fn: async () => {
+        const result = await browser.execute(() => window.devicePixelRatio);
+
+        return isWdioLatest(browser) ? result : result.value;
+    }};
 
     return await withTestCtxMemo.call(browser, action, PIXEL_RATIO);
 };

--- a/lib/commands/orientation.js
+++ b/lib/commands/orientation.js
@@ -1,11 +1,13 @@
 'use strict';
 
 const {resetTestContextValues, TOP_TOOLBAR_SIZE, BOTTOM_TOOLBAR_LOCATION, WEB_VIEW_SIZE} = require('../command-helpers/test-context');
+const {isWdioLatest} = require('../utils');
 
 module.exports = (browser) => {
-    const baseOrientationFn = browser.orientation;
+    const commandName = isWdioLatest(browser) ? 'setOrientation' : 'orientation';
+    const baseOrientationFn = browser[commandName];
 
-    browser.addCommand('orientation', async (orientation) => {
+    browser.addCommand(commandName, async (orientation) => {
         if (orientation && browser.executionContext) {
             resetTestContextValues(browser.executionContext, [TOP_TOOLBAR_SIZE, BOTTOM_TOOLBAR_LOCATION, WEB_VIEW_SIZE]);
         }

--- a/lib/commands/screenshot.js
+++ b/lib/commands/screenshot.js
@@ -5,6 +5,7 @@ const concat = require('concat-stream');
 const streamifier = require('streamifier');
 const {calcWebViewCoords, getPixelRatio} = require('../command-helpers/element-utils');
 const {runInNativeContext} = require('../command-helpers/context-switcher');
+const {isWdioLatest} = require('../utils');
 
 module.exports = (browser) => {
     const baseScreenshotFn = browser.screenshot;
@@ -14,7 +15,8 @@ module.exports = (browser) => {
         const pixelRatio = await getPixelRatio(browser);
         const cropCoords = await runInNativeContext(browser, {fn: calcWebViewCoords, args: [browser, {bodyWidth, pixelRatio}]});
 
-        const {value: base64} = await baseScreenshotFn.call(this);
+        const screenshotResult = await baseScreenshotFn.call(this);
+        const base64 = isWdioLatest(browser) ? screenshotResult : screenshotResult.value;
 
         return new Promise((resolve, reject) => {
             const handleError = (msg) => (err) => reject(`Error occured while ${msg}: ${err.message}`);
@@ -34,7 +36,12 @@ module.exports = (browser) => {
 
                     destination.pack()
                         .on('error', handleError('packing png data to buffer'))
-                        .pipe(concat((buffer) => resolve({value: buffer.toString('base64')})))
+                        .pipe(concat((buffer) => {
+                            const strBase64 = buffer.toString('base64');
+                            const result = isWdioLatest(browser) ? strBase64 : {value: strBase64};
+
+                            resolve(result);
+                        }))
                         .on('error', handleError('concatenating png data to a single buffer'));
                 });
         });

--- a/lib/commands/url.js
+++ b/lib/commands/url.js
@@ -8,12 +8,12 @@ module.exports = (browser, config) => {
 
     browser.addCommand('url', async (uri) => {
         if (!uri) {
-            return baseUrlFn.call(this, uri);
+            return baseUrlFn.call(browser, uri);
         }
 
         // in order to clear the page from previous search result
         await browser.execute(() => document.body.remove());
-        await baseUrlFn.call(this, uri);
+        await baseUrlFn.call(browser, uri);
 
         await browser.waitUntil(
             () => browser.isVisible('body'),

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.isWdioLatest = (browser) => Boolean(browser.overwriteCommand);

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const utils = require('lib/utils');
+
+describe('utils', () => {
+    describe('isWdioLatest', () => {
+        it('should return "true" if "overwriteCommand" method exists', () => {
+            const browser = {overwriteCommand: () => {}};
+
+            assert.isTrue(utils.isWdioLatest(browser));
+        });
+
+        it('should return "false" if "overwriteCommand" method does not exist', () => {
+            const browser = {};
+
+            assert.isFalse(utils.isWdioLatest(browser));
+        });
+    });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -33,6 +33,7 @@ exports.mkBrowser_ = () => {
     session.isVisible = sinon.stub().named('isVisible').resolves();
     session.isExisting = sinon.stub().named('isExisting').resolves(false);
     session.orientation = sinon.stub().named('orientation').resolves({value: 'default-orientation'});
+    session.setOrientation = sinon.stub().named('setOrientation').resolves('default-orientation');
     session.screenshot = sinon.stub().named('screenshot').resolves({value: 'default-base64'});
 
     session.addCommand = sinon.stub().callsFake((name, command) => {


### PR DESCRIPTION
#### What is done:
- add temporary helper - `isLatestWdio` in order to define which version of wdio is used. If it is latest wdio then I use result of commands as is. If not latest then I get result of commands from `value` property;
- `orientation` command doesn't exist in `jsonWireProtocol` (it was custom realization of wdio@4). So if used latest wdio then I wrap `setOrientation` command