### PR TITLE
feat: add nativeElementsSize options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ Plugin has following configuration:
 * **enabled** (optional) `Boolean` – enable/disable the plugin, by default plugin is enabled;
 * **browsers** (required) `Object` - the list of browsers to use for wrap commands;
   * **commands** (required) `Array` - commands which will be wrapped.
+  * **nativeElementsSize** (optional) `Object` - the map of native elements sizes for the browser. Sizes in pixels without counting the pixel ratio. Can be used in order to speed up taking screenshots;
+    * **topToolbar** (required) `Object` - the size of the top toolbar;
+      * **width** (required) `Number` - the width of the top toolbar;
+      * **height** (required) `Number` - the height of the top toolbar;
+    * **bottomToolbar** (required) `Object` - the size of the bottom toolbar;
+      * **width** (required) `Number` - the width of the bottom toolbar;
+      * **height** (required) `Number` - the height of the bottom toolbar;
+    * **webview** (required) `Object` - the size of the webview;
+      * **width** (required) `Number` - the width of the webview;
+      * **height** (required) `Number` - the height of the webview;
+
 
 Also there is ability to override plugin parameters by CLI options or environment variables
 (see [configparser](https://github.com/gemini-testing/configparser)).
@@ -44,7 +55,21 @@ module.exports = {
                             'swipe',
                             'touch',
                             'dragAndDrop'
-                        ]
+                        ],
+                        nativeElementsSize: {
+                            topToolbar: {
+                                height: 47,
+                                width: 390
+                            },
+                            bottomToolbar: {
+                                height: 113,
+                                width: 390
+                            },
+                            webview: {
+                                height: 654,
+                                width: 390
+                            }
+                        }
                     }
                 }
             }

--- a/lib/command-helpers/element-utils/common/index.js
+++ b/lib/command-helpers/element-utils/common/index.js
@@ -1,11 +1,13 @@
 'use strict';
 
+const {runInNativeContext} = require('../../context-switcher');
 const {withExisting, withNativeCtx, withTestCtxMemo} = require('../decorators');
 const {WEB_VIEW_SIZE, BOTTOM_TOOLBAR_LOCATION, PIXEL_RATIO} = require('../../test-context');
 
 module.exports = class CommonUtils {
-    constructor(nativeLocators) {
+    constructor(nativeLocators, nativeElementsSize) {
         this._nativeLocators = nativeLocators;
+        this._nativeElementsSize = nativeElementsSize;
     }
 
     async getLocation(browser, selector) {
@@ -62,7 +64,7 @@ module.exports = class CommonUtils {
         return withTestCtxMemo.call(browser, action, PIXEL_RATIO);
     }
 
-    async calcWebViewCoords(browser, {bodyWidth, pixelRatio = 1} = {}) {
+    async calcWebViewCoordsNative(browser, {bodyWidth, pixelRatio = 1} = {}) {
         const [topToolbarHeight, bottomToolbarY, webViewSize] = await Promise.all([
             this.getTopToolbarHeight(browser),
             this.getBottomToolbarY(browser),
@@ -75,6 +77,34 @@ module.exports = class CommonUtils {
             width: Math.ceil(Math.min(webViewSize.width, bodyWidth) * pixelRatio),
             height: Math.ceil((webViewSize.height - topToolbarHeight - bottomToolbarHeight) * pixelRatio),
             left: Math.max(Math.floor((webViewSize.width - bodyWidth) / 2 * pixelRatio), 0),
+            top: Math.max(Math.floor(topToolbarHeight * pixelRatio), 0)
+        };
+    }
+
+    async calcWebViewCoords(browser, {bodyWidth, pixelRatio = 1} = {}) {
+        if (!this._nativeElementsSize) {
+            return runInNativeContext(browser, {
+                fn: this.calcWebViewCoordsNative.bind(this),
+                args: [browser, {bodyWidth, pixelRatio}]
+            });
+        }
+
+        let {
+            topToolbar: {height: topToolbarHeight},
+            bottomToolbar: {height: bottomToolbarHeight},
+            webview: {width: webviewWidth, height: webviewHeight}
+        } = this._nativeElementsSize;
+
+        if (await browser.getOrientation() === 'LANDSCAPE') {
+            [webviewWidth, webviewHeight] = [webviewHeight, webviewWidth];
+            topToolbarHeight = 0;
+            bottomToolbarHeight = 0;
+        }
+
+        return {
+            width: Math.ceil(Math.min(webviewWidth, bodyWidth) * pixelRatio),
+            height: Math.ceil((webviewHeight - topToolbarHeight - bottomToolbarHeight) * pixelRatio),
+            left: Math.max(Math.floor((webviewWidth - bodyWidth) / 2 * pixelRatio), 0),
             top: Math.max(Math.floor(topToolbarHeight * pixelRatio), 0)
         };
     }

--- a/lib/command-helpers/element-utils/index.js
+++ b/lib/command-helpers/element-utils/index.js
@@ -6,12 +6,12 @@ const {NEW_SAFARI_VERSION} = require('../../constants');
 const Safari15Utils = require('./v15.0');
 const SafariOldUtils = require('./<v15.0');
 
-exports.getElementUtils = (broConfig, nativeLocators) => {
+exports.getElementUtils = (broConfig, nativeLocators, nativeElementsSize) => {
     const currentVersion = getSafariVersion(broConfig);
 
     if (currentVersion < NEW_SAFARI_VERSION) {
-        return new SafariOldUtils(nativeLocators);
+        return new SafariOldUtils(nativeLocators, nativeElementsSize);
     }
 
-    return new Safari15Utils(nativeLocators);
+    return new Safari15Utils(nativeLocators, nativeElementsSize);
 };

--- a/lib/commands/screenshot.js
+++ b/lib/commands/screenshot.js
@@ -1,13 +1,12 @@
 'use strict';
 
 const sharp = require('sharp');
-const {runInNativeContext} = require('../command-helpers/context-switcher');
 
 module.exports = (browser, {elementUtils}) => {
     browser.overwriteCommand('takeScreenshot', async (baseScreenshotFn) => {
         const {width: bodyWidth} = await elementUtils.getElementSize(browser, 'body');
         const pixelRatio = await elementUtils.getPixelRatio(browser);
-        const cropCoords = await runInNativeContext(browser, {fn: elementUtils.calcWebViewCoords.bind(elementUtils), args: [browser, {bodyWidth, pixelRatio}]});
+        const cropCoords = await elementUtils.calcWebViewCoords(browser, {bodyWidth, pixelRatio});
         const screenshotResult = await baseScreenshotFn();
 
         try {

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -2,5 +2,6 @@
 
 module.exports = {
     enabled: true,
-    commands: null
+    commands: null,
+    nativeElementsSize: null
 };

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -23,6 +23,11 @@ const assertArrayOfStrings = (value, name) => {
         throw new Error(`"${name}" must be an array of strings but got ${JSON.stringify(value)}`);
     }
 };
+const assertNumberProperty = (value, prop, propPath) => {
+    if (!_.isNumber(value[prop])) {
+        throw new Error(`Property "${propPath}.${prop}" must be a number but got ${value[prop] === null ? 'null' : typeof value[prop]}`);
+    }
+};
 
 const getParser = () => {
     return root(section({
@@ -41,6 +46,48 @@ const getParser = () => {
                     _.isNull(value)
                         ? thr('Each browser must have "commands" option')
                         : assertArrayOfStrings(value, 'commands');
+                }
+            }),
+            nativeElementsSize: option({
+                defaultValue: defaults.nativeElementsSize,
+                parseEnv: JSON.parse,
+                parseCli: JSON.parse,
+                validate: (value) => {
+                    if (_.isNull(value)) {
+                        return;
+                    }
+
+                    if (!_.isPlainObject(value)) {
+                        throw new Error('"nativeElementsSize" must be an object');
+                    }
+                    const valueProps = _.keys(value);
+
+                    const requiredProps = ['topToolbar', 'bottomToolbar', 'webview'];
+                    const missingProps = requiredProps.filter(prop => !valueProps.includes(prop));
+
+                    if (missingProps.length) {
+                        throw new Error(
+                            `"nativeElementsSize" missing properties: ${missingProps}.`
+                        );
+                    }
+
+                    _.forOwn(value, (size, key) => {
+                        if (!_.isPlainObject(size)) {
+                            throw new Error(`Property "${key}" of "nativeElementsSize" must be an object`);
+                        }
+
+                        assertNumberProperty(size, 'width', `nativeElementsSize.${key}`);
+                        assertNumberProperty(size, 'height', `nativeElementsSize.${key}`);
+                    });
+
+                    const allowedProps = [...requiredProps];
+                    const unknownProps = valueProps.filter(prop => !allowedProps.includes(prop));
+
+                    if (unknownProps.length) {
+                        throw new Error(
+                            `"nativeElementsSize" contains unknown properties: ${unknownProps}. Allowed: ${allowedProps}.`
+                        );
+                    }
                 }
             })
         }))

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ module.exports = (hermione, opts) => {
     }
 
     hermione.on(hermione.events.NEW_BROWSER, (browser, {browserId}) => {
-        const {commands = []} = getBrowserPluginCfg(pluginConfig, browserId);
+        const {commands = [], nativeElementsSize} = getBrowserPluginCfg(pluginConfig, browserId);
 
         if (_.isEmpty(commands)) {
             return;
@@ -51,7 +51,7 @@ module.exports = (hermione, opts) => {
         }
 
         const nativeLocators = getNativeLocators(broConfig);
-        const elementUtils = getElementUtils(broConfig, nativeLocators);
+        const elementUtils = getElementUtils(broConfig, nativeLocators, nativeElementsSize);
         commands.forEach((commandName) => {
             if (!browserCommands[commandName]) {
                 throw new TypeError(`Can not find "${commandName}" command`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "hermione-safari-commands",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "gemini-configparser": "^1.0.0",
+        "gemini-configparser": "^1.3.0",
         "lodash": "^4.17.15",
         "sharp": "~0.31.3"
       },
@@ -3563,9 +3563,9 @@
       "dev": true
     },
     "node_modules/gemini-configparser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gemini-configparser/-/gemini-configparser-1.0.0.tgz",
-      "integrity": "sha1-lKjZTqTqESh9nEChnHSSFo7toCA=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/gemini-configparser/-/gemini-configparser-1.3.2.tgz",
+      "integrity": "sha512-aCbDQIPTpL2RgpsgLLx2eKB+tM/vstAnoj38yzDaZIhwALOK/xaET+4+2ofyRtF/Vi4YzPkTcAmlL9P3LOeOdQ==",
       "dependencies": {
         "lodash": "^4.17.4"
       }
@@ -10186,9 +10186,9 @@
       "dev": true
     },
     "gemini-configparser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gemini-configparser/-/gemini-configparser-1.0.0.tgz",
-      "integrity": "sha1-lKjZTqTqESh9nEChnHSSFo7toCA=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/gemini-configparser/-/gemini-configparser-1.3.2.tgz",
+      "integrity": "sha512-aCbDQIPTpL2RgpsgLLx2eKB+tM/vstAnoj38yzDaZIhwALOK/xaET+4+2ofyRtF/Vi4YzPkTcAmlL9P3LOeOdQ==",
       "requires": {
         "lodash": "^4.17.4"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/gemini-testing/hermione-safari-commands#readme",
   "dependencies": {
-    "gemini-configparser": "^1.0.0",
+    "gemini-configparser": "^1.3.0",
     "lodash": "^4.17.15",
     "sharp": "~0.31.3"
   },

--- a/test/lib/commands/screenshot.js
+++ b/test/lib/commands/screenshot.js
@@ -6,7 +6,7 @@ const {getElementUtils} = require('lib/command-helpers/element-utils');
 const {mkBrowser_} = require('../../utils');
 
 describe('"screenshot" command', () => {
-    let wrapScreenshotCommand, browser, runInNativeContext, elementUtils, mockedSharp, mkSharpInstance;
+    let wrapScreenshotCommand, browser, calcWebViewCoordsStub, elementUtils, mockedSharp, mkSharpInstance;
 
     const mkSharpStub_ = () => {
         const stub = {};
@@ -18,17 +18,15 @@ describe('"screenshot" command', () => {
 
     beforeEach(() => {
         browser = mkBrowser_();
-        runInNativeContext = sinon.stub().resolves({});
         elementUtils = getElementUtils(browser);
         mockedSharp = mkSharpStub_();
         mkSharpInstance = sinon.stub().callsFake(() => mockedSharp);
 
         wrapScreenshotCommand = proxyquire('lib/commands/screenshot', {
-            '../command-helpers/context-switcher': {runInNativeContext},
             sharp: mkSharpInstance
         });
 
-        sinon.stub(elementUtils, 'calcWebViewCoords');
+        calcWebViewCoordsStub = sinon.stub(elementUtils, 'calcWebViewCoords');
     });
 
     afterEach(() => sinon.restore());
@@ -63,7 +61,7 @@ describe('"screenshot" command', () => {
 
     it('should extract image with correct coords', async () => {
         const coords = {left: 0, top: 0, width: 2, height: 2};
-        runInNativeContext.resolves(coords);
+        calcWebViewCoordsStub.resolves(coords);
         wrapScreenshotCommand(browser, {elementUtils});
 
         await browser.takeScreenshot();
@@ -83,7 +81,7 @@ describe('"screenshot" command', () => {
 
         await browser.takeScreenshot();
 
-        assert.deepEqual(runInNativeContext.args[0][1]['args'][1], {
+        assert.deepEqual(calcWebViewCoordsStub.args[0][1], {
             bodyWidth,
             pixelRatio
         });

--- a/test/lib/config/index.js
+++ b/test/lib/config/index.js
@@ -16,6 +16,22 @@ describe('config', () => {
                 commands: ['default-command']
             });
         };
+        const mkNativeElementsSize_ = (opts = {}) => {
+            return _.defaults(opts, {
+                topToolbar: {
+                    height: 47,
+                    width: 390
+                },
+                bottomToolbar: {
+                    height: 113,
+                    width: 390
+                },
+                webview: {
+                    height: 654,
+                    width: 390
+                }
+            });
+        };
 
         describe('commands', () => {
             describe('should throw error if "commands" option', () => {
@@ -50,6 +66,129 @@ describe('config', () => {
                 const config = parseConfig(readConfig);
 
                 assert.deepEqual(config.browsers.b1.commands, ['foo']);
+            });
+        });
+
+        describe('nativeElementsSize', () => {
+            describe('topToolbar', () => {
+                describe('should throw error if "topToolbar.height" option', () => {
+                    it('is not a number', () => {
+                        const readConfig = {
+                            browsers: {
+                                b1: mkBrowser_({nativeElementsSize: mkNativeElementsSize_({topToolbar: {height: '1', width: 1}})})
+                            }
+                        };
+
+                        assert.throws(() => parseConfig(readConfig), Error, 'Property "nativeElementsSize.topToolbar.height" must be a number but got string');
+                    });
+                });
+
+                describe('should throw error if "topToolbar.width" option', () => {
+                    it('is not a number', () => {
+                        const readConfig = {
+                            browsers: {
+                                b1: mkBrowser_({nativeElementsSize: mkNativeElementsSize_({topToolbar: {width: '1', height: 1}})})
+                            }
+                        };
+
+                        assert.throws(() => parseConfig(readConfig), Error, 'Property "nativeElementsSize.topToolbar.width" must be a number but got string');
+                    });
+                });
+
+                it('should set "topToolbar" option', () => {
+                    const readConfig = {
+                        browsers: {
+                            b1: mkBrowser_({nativeElementsSize: mkNativeElementsSize_()})
+                        }
+                    };
+
+                    const config = parseConfig(readConfig);
+
+                    assert.deepEqual(config.browsers.b1.nativeElementsSize.topToolbar, {
+                        height: 47,
+                        width: 390
+                    });
+                });
+            });
+            describe('bottomToolbar', () => {
+                describe('should throw error if "bottomToolbar.height" option', () => {
+                    it('is not a number', () => {
+                        const readConfig = {
+                            browsers: {
+                                b1: mkBrowser_({nativeElementsSize: mkNativeElementsSize_({bottomToolbar: {height: '1', width: 1}})})
+                            }
+                        };
+
+                        assert.throws(() => parseConfig(readConfig), Error, 'Property "nativeElementsSize.bottomToolbar.height" must be a number but got string');
+                    });
+                });
+
+                describe('should throw error if "bottomToolbar.width" option', () => {
+                    it('is not a number', () => {
+                        const readConfig = {
+                            browsers: {
+                                b1: mkBrowser_({nativeElementsSize: mkNativeElementsSize_({bottomToolbar: {width: '1', height: 1}})})
+                            }
+                        };
+
+                        assert.throws(() => parseConfig(readConfig), Error, 'Property "nativeElementsSize.bottomToolbar.width" must be a number but got string');
+                    });
+                });
+
+                it('should set "bottomToolbar" option', () => {
+                    const readConfig = {
+                        browsers: {
+                            b1: mkBrowser_({nativeElementsSize: mkNativeElementsSize_()})
+                        }
+                    };
+
+                    const config = parseConfig(readConfig);
+
+                    assert.deepEqual(config.browsers.b1.nativeElementsSize.bottomToolbar, {
+                        height: 113,
+                        width: 390
+                    });
+                });
+            });
+            describe('webview', () => {
+                describe('should throw error if "webview.height" option', () => {
+                    it('is not a number', () => {
+                        const readConfig = {
+                            browsers: {
+                                b1: mkBrowser_({nativeElementsSize: mkNativeElementsSize_({webview: {height: '1', width: 1}})})
+                            }
+                        };
+
+                        assert.throws(() => parseConfig(readConfig), Error, 'Property "nativeElementsSize.webview.height" must be a number but got string');
+                    });
+                });
+
+                describe('should throw error if "webview.width" option', () => {
+                    it('is not a number', () => {
+                        const readConfig = {
+                            browsers: {
+                                b1: mkBrowser_({nativeElementsSize: mkNativeElementsSize_({webview: {width: '1', height: 1}})})
+                            }
+                        };
+
+                        assert.throws(() => parseConfig(readConfig), Error, 'Property "nativeElementsSize.webview.width" must be a number but got string');
+                    });
+                });
+
+                it('should set "webview" option', () => {
+                    const readConfig = {
+                        browsers: {
+                            b1: mkBrowser_({nativeElementsSize: mkNativeElementsSize_()})
+                        }
+                    };
+
+                    const config = parseConfig(readConfig);
+
+                    assert.deepEqual(config.browsers.b1.nativeElementsSize.webview, {
+                        height: 654,
+                        width: 390
+                    });
+                });
             });
         });
     });

--- a/test/utils.js
+++ b/test/utils.js
@@ -39,6 +39,7 @@ exports.mkBrowser_ = (desiredCapabilities = {}) => {
     session.takeScreenshot = sinon.stub().named('takeScreenshot').resolves('default-base64');
     session.extendOptions = sinon.stub().named('extendOptions').resolves();
     session.$ = sinon.stub().named('$').resolves(element);
+    session.getOrientation = sinon.stub().named('getOrientation').resolves('default-orientation');
 
     session.addCommand = sinon.stub().callsFake((name, command, isElement) => {
         const target = isElement ? element : session;


### PR DESCRIPTION
Added option nativeElementsSize to define the expected sizes of native elements. This will prevent switching to the native context before taking a screenshot